### PR TITLE
feat: remove xray exporter setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Enjoy distributed tracing step by step.
 ```
 $ docker compose up --build
 $ cd client
-$ FORMAT=OTEL go run main.go
+$ go run main.go
 ```
 
 ### Unit test

--- a/api-gateway/go.mod
+++ b/api-gateway/go.mod
@@ -4,7 +4,6 @@ go 1.21.0
 
 require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.43.0
-	go.opentelemetry.io/contrib/propagators/aws v1.18.0
 	go.opentelemetry.io/otel v1.17.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.17.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.17.0

--- a/api-gateway/go.sum
+++ b/api-gateway/go.sum
@@ -25,8 +25,6 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.43.0 h1:HKORGpiOY0R0nAPtKx/ub8/7XoHhRooP8yNRkuPfelI=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.43.0/go.mod h1:e+y1M74SYXo/FcIx3UATwth2+5dDkM8dBi7eXg1tbw8=
-go.opentelemetry.io/contrib/propagators/aws v1.18.0 h1:8SFScyYfxZK/MaW1iW17h/RhHNogbDtpwNJ6Ce95h0A=
-go.opentelemetry.io/contrib/propagators/aws v1.18.0/go.mod h1:0ssYM4GfgGWeoJKLcXduZowVIbIlWd8zCY0CdQqYA0w=
 go.opentelemetry.io/otel v1.17.0 h1:MW+phZ6WZ5/uk2nd93ANk/6yJ+dVrvNWUjGhnnFU5jM=
 go.opentelemetry.io/otel v1.17.0/go.mod h1:I2vmBGtFaODIVMBSTPVDlJSzBDNf93k60E6Ft0nyjo0=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.17.0 h1:U5GYackKpVKlPrd/5gKMlrTlP2dCESAAFU682VCpieY=

--- a/api-gateway/main.go
+++ b/api-gateway/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -11,11 +10,9 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
-	"go.opentelemetry.io/contrib/propagators/aws/xray"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -32,7 +29,6 @@ func fatalLog(err error, message string) {
 }
 
 func registerTracerProvider() (*sdktrace.TracerProvider, error) {
-	format := os.Getenv("FORMAT")
 
 	res := resource.NewWithAttributes(
 		semconv.SchemaURL,
@@ -50,35 +46,6 @@ func registerTracerProvider() (*sdktrace.TracerProvider, error) {
 		fatalLog(err, "failed to create new OTLP trace exporter")
 		return nil, err
 	}
-
-	if format == "XRAY" {
-		tp := newTracerProviderWithXRayExporter(res, spanExporter)
-		otel.SetTextMapPropagator(xray.Propagator{})
-		return tp, err
-	} else if format == "OTEL" {
-		tp := newTracerProviderWithOtlpExporter(res, spanExporter)
-		otel.SetTextMapPropagator(propagation.TraceContext{})
-		return tp, err
-	} else {
-		return nil, errors.New("environment variable FORMAT (XRAY or OTEL)not set")
-	}
-}
-
-func newTracerProviderWithXRayExporter(res *resource.Resource, spanExporter *otlptrace.Exporter) *sdktrace.TracerProvider {
-	idg := xray.NewIDGenerator()
-
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithResource(res),
-		sdktrace.WithBatcher(spanExporter),
-		sdktrace.WithIDGenerator(idg),
-	)
-
-	otel.SetTracerProvider(tp)
-	return tp
-}
-
-func newTracerProviderWithOtlpExporter(res *resource.Resource, spanExporter *otlptrace.Exporter) *sdktrace.TracerProvider {
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithResource(res),
@@ -86,8 +53,8 @@ func newTracerProviderWithOtlpExporter(res *resource.Resource, spanExporter *otl
 	)
 
 	otel.SetTracerProvider(tp)
-
-	return tp
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	return tp, err
 }
 
 func printSpanContextInfo(name string, spanContext trace.SpanContext) {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,7 +4,6 @@ go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.8.4
-	go.opentelemetry.io/contrib/propagators/aws v1.18.0
 	go.opentelemetry.io/otel v1.17.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.17.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.17.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -27,8 +27,6 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-go.opentelemetry.io/contrib/propagators/aws v1.18.0 h1:8SFScyYfxZK/MaW1iW17h/RhHNogbDtpwNJ6Ce95h0A=
-go.opentelemetry.io/contrib/propagators/aws v1.18.0/go.mod h1:0ssYM4GfgGWeoJKLcXduZowVIbIlWd8zCY0CdQqYA0w=
 go.opentelemetry.io/otel v1.17.0 h1:MW+phZ6WZ5/uk2nd93ANk/6yJ+dVrvNWUjGhnnFU5jM=
 go.opentelemetry.io/otel v1.17.0/go.mod h1:I2vmBGtFaODIVMBSTPVDlJSzBDNf93k60E6Ft0nyjo0=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.17.0 h1:U5GYackKpVKlPrd/5gKMlrTlP2dCESAAFU682VCpieY=

--- a/client/go.mod
+++ b/client/go.mod
@@ -4,7 +4,6 @@ go 1.21.0
 
 require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.43.0
-	go.opentelemetry.io/contrib/propagators/aws v1.18.0
 	go.opentelemetry.io/otel v1.17.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.17.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.17.0

--- a/client/go.sum
+++ b/client/go.sum
@@ -25,8 +25,6 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.43.0 h1:HKORGpiOY0R0nAPtKx/ub8/7XoHhRooP8yNRkuPfelI=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.43.0/go.mod h1:e+y1M74SYXo/FcIx3UATwth2+5dDkM8dBi7eXg1tbw8=
-go.opentelemetry.io/contrib/propagators/aws v1.18.0 h1:8SFScyYfxZK/MaW1iW17h/RhHNogbDtpwNJ6Ce95h0A=
-go.opentelemetry.io/contrib/propagators/aws v1.18.0/go.mod h1:0ssYM4GfgGWeoJKLcXduZowVIbIlWd8zCY0CdQqYA0w=
 go.opentelemetry.io/otel v1.17.0 h1:MW+phZ6WZ5/uk2nd93ANk/6yJ+dVrvNWUjGhnnFU5jM=
 go.opentelemetry.io/otel v1.17.0/go.mod h1:I2vmBGtFaODIVMBSTPVDlJSzBDNf93k60E6Ft0nyjo0=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.17.0 h1:U5GYackKpVKlPrd/5gKMlrTlP2dCESAAFU682VCpieY=

--- a/client/main.go
+++ b/client/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -15,8 +14,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 
-	"go.opentelemetry.io/contrib/propagators/aws/xray"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -33,11 +30,10 @@ func fatalLog(err error, message string) {
 }
 
 func registerTracerProvider() (*sdktrace.TracerProvider, error) {
-	format := os.Getenv("FORMAT")
 
 	res := resource.NewWithAttributes(
 		semconv.SchemaURL,
-		semconv.ServiceNameKey.String("gateway-service"),
+		semconv.ServiceNameKey.String("client"),
 	)
 
 	ctx := context.Background()
@@ -51,35 +47,6 @@ func registerTracerProvider() (*sdktrace.TracerProvider, error) {
 		fatalLog(err, "failed to create new OTLP trace exporter")
 		return nil, err
 	}
-
-	if format == "XRAY" {
-		tp := newTracerProviderWithXRayExporter(res, spanExporter)
-		otel.SetTextMapPropagator(xray.Propagator{})
-		return tp, err
-	} else if format == "OTEL" {
-		tp := newTracerProviderWithOtlpExporter(res, spanExporter)
-		otel.SetTextMapPropagator(propagation.TraceContext{})
-		return tp, err
-	} else {
-		return nil, errors.New("environment variable FORMAT (XRAY or OTEL)not set")
-	}
-}
-
-func newTracerProviderWithXRayExporter(res *resource.Resource, spanExporter *otlptrace.Exporter) *sdktrace.TracerProvider {
-	idg := xray.NewIDGenerator()
-
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithResource(res),
-		sdktrace.WithBatcher(spanExporter),
-		sdktrace.WithIDGenerator(idg),
-	)
-
-	otel.SetTracerProvider(tp)
-	return tp
-}
-
-func newTracerProviderWithOtlpExporter(res *resource.Resource, spanExporter *otlptrace.Exporter) *sdktrace.TracerProvider {
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithResource(res),
@@ -87,8 +54,8 @@ func newTracerProviderWithOtlpExporter(res *resource.Resource, spanExporter *otl
 	)
 
 	otel.SetTracerProvider(tp)
-
-	return tp
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	return tp, err
 }
 
 func retrieveResponse() ([]byte, error) {

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,6 @@ services:
             context: ./api-gateway
         environment:
           - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317
-          - FORMAT=OTEL
           - BACKEND_ENDPOINT=http://backend:3000/hello
         ports: 
             - 8080:8080
@@ -17,7 +16,6 @@ services:
             context: ./backend
         environment:
           - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317
-          - FORMAT=OTEL
         ports: 
             - 3000:3000
         depends_on:


### PR DESCRIPTION
AWS X-Ray now supports W3C format trace IDs with ADOT collector v0.34 or higher. You do not need to use XrayIdGenerator anymore. For simplicity I removed XrayIdGenerator and XRay propagation.

cf) https://aws.amazon.com/about-aws/whats-new/2023/10/aws-x-ray-w3c-format-trace-ids-distributed-tracing/